### PR TITLE
ignore client disconnect error

### DIFF
--- a/lib/shell-client.js
+++ b/lib/shell-client.js
@@ -27,6 +27,7 @@ class ShellClient extends EventEmitter {
     this._client.on('authentication', this._handleAuthentication.bind(this));
     this._client.on('ready', this._handleReady.bind(this));
     this._client.on('end', this._handleEnd.bind(this));
+    this._client.on('error', function() {});  // ignore errors
   }
 
   _handleAuthentication(ctx) {


### PR DESCRIPTION
Hi, When use Ctrl+C to exit connection in shell

```
The authenticity of host '[192.168.*]:9022 ([192.168*]:9022)' can't be established.
RSA key fingerprint is SHA256:WZOqjuMH4AWzTQ5ZqJT8tQ70GcOtzovA378dNLqKgks.
Are you sure you want to continue connecting (yes/no/[fingerprint])? ^C
```

client will throw an exception. because the client object doesn't listening to an 'error' event. we can add an listening to ignore this exception.